### PR TITLE
106 protonreco

### DIFF
--- a/TopAnalysis/interface/EfficiencyScaleFactorsWrapper.h
+++ b/TopAnalysis/interface/EfficiencyScaleFactorsWrapper.h
@@ -14,7 +14,7 @@ typedef std::pair<float,float> EffCorrection_t;
 class EfficiencyScaleFactorsWrapper
 {
  public:
-  EfficiencyScaleFactorsWrapper(bool isData,TString era);
+  EfficiencyScaleFactorsWrapper(bool isData,TString era, TString eleid);
   EffCorrection_t getMuonSF(float pt,float eta);
   EffCorrection_t getElectronSF(float pt,float eta);
   EffCorrection_t getPhotonSF(float pt,float eta);
@@ -27,7 +27,7 @@ class EfficiencyScaleFactorsWrapper
   ~EfficiencyScaleFactorsWrapper();
 
  private:
-  void init(TString era);
+  void init(TString era, TString eleid);
   int era_;
   std::map<TString,TH2 *> scaleFactorsH_;
   std::map<TString,TH1 *> scaleFactors1DH_;

--- a/TopAnalysis/src/EfficiencyScaleFactorsWrapper.cc
+++ b/TopAnalysis/src/EfficiencyScaleFactorsWrapper.cc
@@ -10,10 +10,10 @@
 using namespace std;
 
 //
-EfficiencyScaleFactorsWrapper::EfficiencyScaleFactorsWrapper(bool isData,TString era)
+EfficiencyScaleFactorsWrapper::EfficiencyScaleFactorsWrapper(bool isData,TString era,TString eleid)
 {
   if(isData) return;
-  init(era);
+  init(era, eleid);
 }
 
 //
@@ -24,6 +24,7 @@ void EfficiencyScaleFactorsWrapper::init(TString era)
 
   cout << "[EfficiencyScaleFactorsWrapper]" << endl
        << "\tStarting efficiency scale factors for " << era << endl
+       << "\tThe ID of electrons is " << eleid << endl
        << "\tWarnings: no trigger SFs for any object" << endl
        << "\t          uncertainties returned are of statistical nature only" << endl
        << "\tDon't forget to fix these and update these items!" << endl;
@@ -35,8 +36,17 @@ void EfficiencyScaleFactorsWrapper::init(TString era)
     a_idSF=era+"/Fall17V2_2016_Tight_photons.root";
     a_psvSF=era+"/ScalingFactors_80X_Summer16.root";
   }else if(era_==2017){
-    a_recoSF=era+"/egammaEffi.txt_EGM2D_runBCDEF_passingRECO.root";
-    a_idSF=era+"/2017_PhotonsTight.root";
+    if(eleid.Contains("LOOSE"))a_idSF=era+"/egammaEffi.txt_EGM2D_Loose_UL17.root";
+    if(eleid.Contains("MEDIUM"))a_idSF=era+"/egammaEffi.txt_EGM2D_Medium_UL17.root";
+    if(eleid.Contains("TIGHT"))a_idSF=era+"/egammaEffi.txt_EGM2D_Tight_UL17.root";
+    if(eleid.Contains("VETO"))a_idSF=era+"/egammaEffi.txt_EGM2D_Veto_UL17.root";
+    if(eleid.Contains("MVA80ISO"))a_idSF=era+"/egammaEffi.txt_EGM2D_MVA80iso_UL17.root";
+    if(eleid.Contains("MVA80NOISO"))a_idSF=era+"/egammaEffi.txt_EGM2D_MVA80noIso_UL17.root";
+    if(eleid.Contains("MVA90ISO"))a_idSF=era+"/egammaEffi.txt_EGM2D_MVA90iso_UL17.root";
+    if(eleid.Contains("MVA90NOISO"))a_idSF=era+"/egammaEffi.txt_EGM2D_MVA90noIso_UL17.root";
+    a_recoSF=era+"/egammaEffi_ptAbove20.txt_EGM2D_UL2017.root";
+//    a_recoSF=era+"/egammaEffi.txt_EGM2D_runBCDEF_passingRECO.root";
+//    a_idSF=era+"/2017_PhotonsTight.root";
     a_psvSF=era+"/PixelSeed_ScaleFactors_2017.root";
   }
 

--- a/TopAnalysis/src/EfficiencyScaleFactorsWrapper.cc
+++ b/TopAnalysis/src/EfficiencyScaleFactorsWrapper.cc
@@ -17,7 +17,7 @@ EfficiencyScaleFactorsWrapper::EfficiencyScaleFactorsWrapper(bool isData,TString
 }
 
 //
-void EfficiencyScaleFactorsWrapper::init(TString era)
+void EfficiencyScaleFactorsWrapper::init(TString era, TString eleid)
 {
   if(era.Contains("era2017")) era_=2017;
   if(era.Contains("era2016")) era_=2016;

--- a/TopAnalysis/src/ExYukawa.cc
+++ b/TopAnalysis/src/ExYukawa.cc
@@ -53,7 +53,7 @@ void RunExYukawa(const TString in_fname,
   std::map<Int_t,Float_t> lumiPerRun=lumi.lumiPerRun();
 
   //CORRECTIONS: LEPTON EFFICIENCIES
-  EfficiencyScaleFactorsWrapper lepEffH(in_fname.Contains("Data13TeV"),era);
+  EfficiencyScaleFactorsWrapper lepEffH(in_fname.Contains("Data13TeV"),era,"TIGHT");
 
   //CORRECTIONS: L1-prefire
   L1PrefireEfficiencyWrapper l1PrefireWR(in_fname.Contains("Data13TeV"),era);

--- a/TopAnalysis/src/SMP-19-005.cc
+++ b/TopAnalysis/src/SMP-19-005.cc
@@ -48,7 +48,7 @@ void RunSMP19005(TString filename,
   double normWgt(normH ? normH->GetBinContent(1) : 1.0);
 
   //efficiency corrections
-  EfficiencyScaleFactorsWrapper effSF(isData,era);
+  EfficiencyScaleFactorsWrapper effSF(isData,era,"TIGHT");
   L1PrefireEfficiencyWrapper l1prefire(isData,era);
 
   //READ TREE FROM FILE

--- a/TopAnalysis/src/TopSummer2019.cc
+++ b/TopAnalysis/src/TopSummer2019.cc
@@ -50,7 +50,7 @@ void RunTopSummer2019(const TString in_fname,
   std::map<Int_t,Float_t> lumiPerRun=lumi.lumiPerRun();
   
   //CORRECTIONS: LEPTON EFFICIENCIES
-  EfficiencyScaleFactorsWrapper lepEffH(in_fname.Contains("Data13TeV"),era);
+  EfficiencyScaleFactorsWrapper lepEffH(in_fname.Contains("Data13TeV"),era,"TIGHT");
 
   //CORRECTIONS: L1-prefire 
   L1PrefireEfficiencyWrapper l1PrefireWR(in_fname.Contains("Data13TeV"),era);


### PR DESCRIPTION
update eleSF wrapper, the ID of ele could be "loose, medium, tight, veto, MVA80, MVA80noiso, MVA90, MVA90noiso". the reco SF of ele using the "egammaEffi_ptAbove20.txt_EGM2D_UL2017.root" only. some related src file using the wrapper, e.g., TopSummer2019.cc, SMP-19-005.cc are also modified.